### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,8 @@
-ShiftBrite KEYWORD1
-Color KEYWORD1
-setColor KEYWORD2
-setRgbVal KEYWORD2
-getColor KEYWORD2
-getColors KEYWORD2
-colorName KEYWORD2
-WriteLEDArray KEYWORD2
+ShiftBrite	KEYWORD1
+Color	KEYWORD1
+setColor	KEYWORD2
+setRgbVal	KEYWORD2
+getColor	KEYWORD2
+getColors	KEYWORD2
+colorName	KEYWORD2
+WriteLEDArray	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords